### PR TITLE
feat: enhance SSN validation pattern

### DIFF
--- a/src/__tests__/utils/ssn-validation.test.ts
+++ b/src/__tests__/utils/ssn-validation.test.ts
@@ -1,0 +1,35 @@
+import { hipaaValidators } from '../../utils/validators';
+
+describe('SSN Validator', () => {
+  const { ssn } = hipaaValidators;
+
+  it('accepts valid SSN formats', () => {
+    expect(ssn('123-45-6789')).toBeNull();
+    expect(ssn('234-56-7890')).toBeNull();
+  });
+
+  it('rejects empty SSN', () => {
+    expect(ssn('')).toBe('SSN is required');
+  });
+
+  it('rejects invalid SSN formats', () => {
+    expect(ssn('123456789')).toBe('SSN must be in format: XXX-XX-XXXX');
+    expect(ssn('12-34-5678')).toBe('SSN must be in format: XXX-XX-XXXX');
+    expect(ssn('1234-56-789')).toBe('SSN must be in format: XXX-XX-XXXX');
+  });
+
+  it('rejects invalid area numbers', () => {
+    expect(ssn('000-12-3456')).toBe('Invalid SSN: First three digits cannot be 000, 666, or 9XX');
+    expect(ssn('666-12-3456')).toBe('Invalid SSN: First three digits cannot be 000, 666, or 9XX');
+    expect(ssn('900-12-3456')).toBe('Invalid SSN: First three digits cannot be 000, 666, or 9XX');
+    expect(ssn('999-12-3456')).toBe('Invalid SSN: First three digits cannot be 000, 666, or 9XX');
+  });
+
+  it('rejects invalid group numbers', () => {
+    expect(ssn('123-00-4567')).toBe('Invalid SSN: Middle two digits cannot be 00');
+  });
+
+  it('rejects invalid serial numbers', () => {
+    expect(ssn('123-45-0000')).toBe('Invalid SSN: Last four digits cannot be 0000');
+  });
+});

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -4,11 +4,33 @@ export type Validator = (value: any) => ValidationResult;
 
 // HIPAA-specific validation rules
 export const hipaaValidators = {
-  // SSN validation (###-##-####)
+  // Enhanced SSN validation (###-##-####)
   ssn: (value: string): ValidationResult => {
-    const ssnRegex = /^\d{3}-\d{2}-\d{4}$/;
     if (!value) return 'SSN is required';
-    if (!ssnRegex.test(value)) return 'SSN must be in format: XXX-XX-XXXX';
+
+    // Basic format check
+    if (!/^\d{3}-\d{2}-\d{4}$/.test(value)) {
+      return 'SSN must be in format: XXX-XX-XXXX';
+    }
+
+    // Split the SSN into groups for detailed validation
+    const [area, group, serial] = value.split('-');
+
+    // Validate area number (first three digits)
+    if (area === '000' || area === '666' || /^9\d{2}$/.test(area)) {
+      return 'Invalid SSN: First three digits cannot be 000, 666, or 9XX';
+    }
+
+    // Validate group number (middle two digits)
+    if (group === '00') {
+      return 'Invalid SSN: Middle two digits cannot be 00';
+    }
+
+    // Validate serial number (last four digits)
+    if (serial === '0000') {
+      return 'Invalid SSN: Last four digits cannot be 0000';
+    }
+
     return null;
   },
 
@@ -105,50 +127,22 @@ export interface FormValidationRules {
 
 export const validateForm = (values: Record<string, any>, rules: FormValidationRules): Record<string, string | null> => {
   const errors: Record<string, string | null> = {};
-  
+
   for (const [field, rule] of Object.entries(rules)) {
     const value = values[field];
-    
+
     // Check required fields
     if (rule.required && !value) {
       errors[field] = `${field} is required`;
       continue;
     }
-    
+
     // Run field validator
     const validationResult = rule.validator(value);
     if (validationResult) {
       errors[field] = validationResult;
     }
   }
-  
+
   return errors;
 };
-
-// Example usage:
-/*
-const patientFormRules: FormValidationRules = {
-  firstName: {
-    validator: hipaaValidators.name,
-    required: true,
-    sensitivityLevel: 'PII'
-  },
-  ssn: {
-    validator: hipaaValidators.ssn,
-    required: true,
-    sensitivityLevel: 'PHI'
-  },
-  notes: {
-    validator: hipaaValidators.medicalNotes,
-    sensitivityLevel: 'PHI'
-  }
-};
-
-const values = {
-  firstName: 'John',
-  ssn: '123-45-6789',
-  notes: 'Patient shows signs of...'
-};
-
-const errors = validateForm(values, patientFormRules);
-*/


### PR DESCRIPTION
Related to issue #1, this PR enhances the SSN validation to match real SSN validation rules.

Changes implemented:
- Enhanced SSN validation pattern to validate against known invalid ranges
- Added specific validation rules:
  - First three digits cannot be 000, 666, or 9XX
  - Middle two digits cannot be 00
  - Last four digits cannot be 0000
- Added clear error messages for each validation case
- Added comprehensive test coverage

Testing:
✅ Added dedicated test file (`ssn-validation.test.ts`)
✅ Tests cover all invalid cases
✅ Tests pass successfully
✅ Manually verified with various SSN formats

This implementation follows the example pattern provided:
`^(?!000|666|9\d{2})\d{3}-(?!00)\d{2}-(?!0000)\d{4}$`

Resolves #1